### PR TITLE
fix: Open stdin and enable teletype for minitwit container

### DIFF
--- a/remote_files/compose.yml
+++ b/remote_files/compose.yml
@@ -2,6 +2,8 @@ services:
   minitwitimage:
     image: ${DOCKER_USERNAME}/minitwitimage
     container_name: minitwit
+    stdin_open: true
+    tty: true
     networks:
       - main
     depends_on:


### PR DESCRIPTION
This PR closes #73 

To verify, you can check out this branch, make sure you are able to pull both images in the compose.yml and do the following:

```shell
cd remote_files && \
docker compose up -d && \
sleep 5 && \
docker attach minitwit
```
Then open http://localhost:4567 to verify website is up and notice the get request in your terminal. Escape from the container `Ctrl+p, Ctrl+q` and verify that localhost:4567 is still available.
 