### PR TITLE
fix: register now returns 204 instead of 200

### DIFF
--- a/src/minitwit/controllers/api_controller.rb
+++ b/src/minitwit/controllers/api_controller.rb
@@ -40,7 +40,7 @@ class ApiController < BaseController
     result = register_user(username, email, password)
     
     if result[:success]
-      status 200
+      status 204
       JSON.generate({ 'message': 'Account creation successful' })
     else
       status 400


### PR DESCRIPTION
The simulator we were given in python returns a 204 after a successful register but we were returning a 200. I'm hoping this fixes the issues with the simulator detecting errors for register.