### PR TITLE
131 setup env file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,7 +14,7 @@
 /tmp/
 
 # Used by dotenv library to load environment variables.
-.env
+.env*
 .envrc
 
 # Ignore bin

--- a/README.md
+++ b/README.md
@@ -2,6 +2,21 @@
 
 Project repository for group 'the happy group'
 
+## Environment variables and Vagrant
+
+We are using a package called dotenv for managing environment variables. In order to install the package, run `bundle install` from your terminal.
+
+We must never expose our .env file public, because it contains secrets. Therefore it is ignored in our .gitignore. All developers must have a .env file located in the root folder of our project. Information about how to set this up is shared elsewhere.
+
+In order to be able to run vagrant commands, such as `vagrant provision` and `vagrant rsync`, you must have the following plugins installed to vagrant:
+
+```
+vagrant-digitalocean (0.9.6, global)
+vagrant-env (0.0.3, global)
+vagrant-reload (0.0.1, global)
+vagrant-scp (0.5.9, global)
+```
+
 ## Ruby installation
 
 Requires ruby version >= 3.4.1


### PR DESCRIPTION
The following PR fixes the issues regarding our environment secrets. Instead of having each developer set them locally, we have opt'ed for a tool called dotenv, which is available for Ruby.

- I added a guide / description on how to set this up in the readme
- I ensured the .gitignore also ignores all types of .env files
- environment variables from the dotenv package were already loaded in the project, because @DumbDane already had it setup for him. So I didn't need to add anything additional here.
- Because the variables are loaded when you run the project, I had to find a way to make them available in our Vagrantfile as well. Luckily, there's also a vagrant plugin for that, called vagrant-env. Instructions on what plugins to have installed is provided in the readme. Basically the plugin just enables the .env file, so that Vagrant is able to access it. Adding the following line enables the plugin and allows Vagrant to access the environment variables defined in the .env file
```ruby
Vagrant.configure("2") do |config|
  config.env.enable
...
```
- I also changed the unique_hostname to be the name of our webserver, so that we can run vagrant commands
- All developers must still add a .env file to the root of the project. Instructions are given in the general discord channel.