### PR TITLE
fix: Only close database connection when shutting down website

### DIFF
--- a/src/minitwit/controllers/api_controller.rb
+++ b/src/minitwit/controllers/api_controller.rb
@@ -9,7 +9,6 @@ class ApiController < BaseController
 
   after do
     update_latest
-    close_db
   end
 
   # Latest action

--- a/src/minitwit/helpers/db_helper.rb
+++ b/src/minitwit/helpers/db_helper.rb
@@ -106,8 +106,7 @@ module DbHelper
   end
 
   at_exit do
-    puts "Closing database connections..."
+    puts 'Closing database connections...'
     close_db
   end
-
 end

--- a/src/minitwit/helpers/db_helper.rb
+++ b/src/minitwit/helpers/db_helper.rb
@@ -1,7 +1,7 @@
 module DbHelper
   # Database connection helper with Sequel
   def self.db
-    @db ||= Sequel.connect(MiniTwit::DATABASE)
+    @db ||= Sequel.connect(MiniTwit::DATABASE, max_connections: 10)
   end
 
   # Instance method to access the class methods
@@ -104,4 +104,10 @@ module DbHelper
   def close_db
     DbHelper.close_db
   end
+
+  at_exit do
+    puts "Closing database connections..."
+    close_db
+  end
+
 end


### PR DESCRIPTION
We don't really have any stress tests in our suite so I can't actually verify that this will work, but if my theory (stolen from @lauritsbrok) is correct then this should resolve our issues with the database. Closes #134 

- #134 
