### PR TITLE
Fixing the hadolint linter in Development

### DIFF
--- a/images/Dockerfile.test
+++ b/images/Dockerfile.test
@@ -2,12 +2,12 @@ FROM python:3.13-alpine
 
 # Install Firefox and required tools using apk
 RUN apk add --no-cache \
-    firefox-esr \
-    wget \
-    tar
+    firefox-esr=128.8.0-r0 \
+    wget=1.25.0-r1 \
+    tar=1.35-r3
 
 # Download and install the latest geckodriver (recommended version for Firefox 136.0.1)
-RUN wget https://github.com/mozilla/geckodriver/releases/download/v0.36.0/geckodriver-v0.36.0-linux64.tar.gz && \
+RUN wget -nv https://github.com/mozilla/geckodriver/releases/download/v0.36.0/geckodriver-v0.36.0-linux64.tar.gz && \
     tar -xzf geckodriver-v0.36.0-linux64.tar.gz && \
     mv geckodriver /usr/local/bin/ && \
     chmod +x /usr/local/bin/geckodriver

--- a/images/Dockerfile.test
+++ b/images/Dockerfile.test
@@ -6,7 +6,7 @@ RUN apk add --no-cache \
     tar=1.35-r2 \
     wget=1.25.0-r0 \
 # Download and install the latest geckodriver (recommended version for Firefox 136.0.1)
-    && wget -nv https://github.com/mozilla/geckodriver/releases/download/v0.36.0/geckodriver-v0.36.0-linux64.tar.gz && \
+    && wget --secure-protocol=TLSv1_2 --max-redirect=0 -nv https://github.com/mozilla/geckodriver/releases/download/v0.36.0/geckodriver-v0.36.0-linux64.tar.gz && \
     tar -xzf geckodriver-v0.36.0-linux64.tar.gz && \
     mv geckodriver /usr/local/bin/ && \
     chmod +x /usr/local/bin/geckodriver

--- a/images/Dockerfile.test
+++ b/images/Dockerfile.test
@@ -6,7 +6,7 @@ RUN apk add --no-cache \
     tar=1.35-r2 \
     wget=1.25.0-r0 \
 # Download and install the latest geckodriver (recommended version for Firefox 136.0.1)
-    && wget --secure-protocol=TLSv1_2 --max-redirect=0 -nv https://github.com/mozilla/geckodriver/releases/download/v0.36.0/geckodriver-v0.36.0-linux64.tar.gz && \
+    && wget -nv https://github.com/mozilla/geckodriver/releases/download/v0.36.0/geckodriver-v0.36.0-linux64.tar.gz && \
     tar -xzf geckodriver-v0.36.0-linux64.tar.gz && \
     mv geckodriver /usr/local/bin/ && \
     chmod +x /usr/local/bin/geckodriver

--- a/images/Dockerfile.test
+++ b/images/Dockerfile.test
@@ -3,8 +3,8 @@ FROM python:3.13-alpine
 # Install Firefox and required tools using apk
 RUN apk add --no-cache \
     firefox-esr=128.8.0-r0 \
-    wget=1.25.0-r1 \
-    tar=1.35-r3
+    wget=1.25.0-r0 \
+    tar=1.35-r2
 
 # Download and install the latest geckodriver (recommended version for Firefox 136.0.1)
 RUN wget -nv https://github.com/mozilla/geckodriver/releases/download/v0.36.0/geckodriver-v0.36.0-linux64.tar.gz && \

--- a/images/Dockerfile.test
+++ b/images/Dockerfile.test
@@ -3,11 +3,10 @@ FROM python:3.13-alpine
 # Install Firefox and required tools using apk
 RUN apk add --no-cache \
     firefox-esr=128.8.0-r0 \
+    tar=1.35-r2 \
     wget=1.25.0-r0 \
-    tar=1.35-r2
-
 # Download and install the latest geckodriver (recommended version for Firefox 136.0.1)
-RUN wget -nv https://github.com/mozilla/geckodriver/releases/download/v0.36.0/geckodriver-v0.36.0-linux64.tar.gz && \
+    && wget -nv https://github.com/mozilla/geckodriver/releases/download/v0.36.0/geckodriver-v0.36.0-linux64.tar.gz && \
     tar -xzf geckodriver-v0.36.0-linux64.tar.gz && \
     mv geckodriver /usr/local/bin/ && \
     chmod +x /usr/local/bin/geckodriver


### PR DESCRIPTION
Appearantly the hadolint was not running properly on the `dev` branch, as it found errors and warnings in the Dockerfile.test.

I fixed the errors now so we
- add latest version to packages [(see DL3018)](https://github.com/hadolint/hadolint/wiki/DL3018)
   - package versions found in [pgs.alpinelinux](https://pkgs.alpinelinux.org/packages?name=&branch=edge&repo=&arch=x86_64&origin=&flagged=&maintainer=)
- add -nv flag as proposed in the errors [(see DL304)](https://github.com/hadolint/hadolint/wiki/DL3047)