### PR TITLE
fix: remove prometheus endpoint from the scrape configs

### DIFF
--- a/remote_files/prometheus.yml
+++ b/remote_files/prometheus.yml
@@ -10,18 +10,7 @@ rule_files:
   - 'prometheus.rules.yml'
 
 scrape_configs:
-  - job_name: 'prometheus'
-
-    # Override the global default and scrape targets from this job every 5 seconds.
-    scrape_interval: 5s
-
-    static_configs:
-      - targets: ['prometheus:9090']
-
-  - job_name:       'itu-minittwit-app'
-
-    # Override the global default and scrape targets from this job every 5 seconds.
-    scrape_interval: 5s
+  - job_name:       'itu-minitwit-app'
 
     static_configs:
       - targets: ['minitwit:4567']


### PR DESCRIPTION
Removed self monitoring and the override changing the scrape interval to 5 seconds. 