### PR TITLE
Hotfix: Rubocop linter fails

### DIFF
--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -8,8 +8,7 @@ jobs:
 
     steps:
       - name: Checkout latest version
-      - uses: actions/checkout@v4
-      
+        uses: actions/checkout@v4
       - name: Set up Ruby 3.4
         uses: ruby/setup-ruby@v1
         with:


### PR DESCRIPTION
Realised that the Rubocop linter fails, but I spotted the error. It was simply a faulty placed - under uses.